### PR TITLE
fix error when there is no ~/.ginatra/config.yml file

### DIFF
--- a/lib/ginatra/config.rb
+++ b/lib/ginatra/config.rb
@@ -27,7 +27,7 @@ module Ginatra
         puts "Cannot parse your config file #{ex.message}."
         custom_config = {}
       end
-      final_config.merge!(custom_config)
+      final_config.merge!(custom_config || {})
     else
       puts "User config file #{custom_config_file} absent. Will only see repos in #{final_config["git_dirs"].join(", ")}."
     end


### PR DESCRIPTION
If the `~/.ginatra/config.yml` file doesn't exist, then `custom_config = YAML.load_file(custom_config_file)` evaluates to false.

This causes an error in `final_config.merge!(custom_config)` because `hash.merge(false)` is invalid.

So I changed it to `final_config.merge!(custom_config || {})` which gets the server running for me.